### PR TITLE
(NFC) move initialization into functions

### DIFF
--- a/src/optimize/problem_types.jl
+++ b/src/optimize/problem_types.jl
@@ -260,6 +260,37 @@ end
   ∇f(x) calls:   53
 =#
 
+# B not provided
+# Construct a matrix on the correct form and of the correct type
+# with the content of I_{n,n}
+function init_B(aproach, ::Nothing, x0)
+  return I + abs.(0 * x * x')
+end
+
+# We don't need to maintain a dense matrix for Gradient Descent
+function init_B(aproach::GradientDescent, ::Nothing, x0)
+  return I
+end
+
+function init_B(aproach::LBFGS, ::Nothing, x0)
+  return nothing
+end
+
+# B provided  
+function init_B(aproach, B, x0)
+  return B
+end
+
+#init fz,∇fz,B, allows overloading later by NEqProblem
+function init_f∇fB(prob, scheme, ∇fz, B, x)
+   fz, ∇fz = upto_gradient(prob, ∇fz, x)
+   return fz, ∇fz, B
+end
+
+function init_f∇fB(prob, scheme::Newton, ∇fz, B, x)
+   upto_hessian(prob, ∇fz, B, x)
+end 
+
 function prepare_variables(prob, approach, x0, ∇fz, B)
     objective = prob.objective
     z = x0
@@ -268,25 +299,10 @@ function prepare_variables(prob, approach, x0, ∇fz, B)
         !any(clamp.(x0, lowerbounds(prob), upperbounds(prob)) .!= x0) ||
             error("Initial guess not in the feasible region")
     end
-
-    if isa(B, Nothing)  # didn't provide a B
-        if modelscheme(approach) isa GradientDescent
-            # We don't need to maintain a dense matrix for Gradient Descent
-            B = I
-        elseif modelscheme(approach) isa LBFGS
-            B = nothing
-        else
-            # Construct a matrix on the correct form and of the correct type
-            # with the content of I_{n,n}
-            B = I + abs.(0 * x * x')
-        end
-    end
+    
+    B = init_B(approach, B, x0)
     # first evaluation
-    if isa(modelscheme(approach), Newton)
-        fz, ∇fz, B = upto_hessian(prob, ∇fz, B, x)
-    else
-        fz, ∇fz = upto_gradient(prob, ∇fz, x)
-    end
+    fz, ∇fz, B = init_f∇fB(prob, modelscheme(approach), ∇fz, B, x)
     fx = copy(fz)
     ∇fx = copy(∇fz)
     Pg = ∇fz

--- a/src/optimize/problem_types.jl
+++ b/src/optimize/problem_types.jl
@@ -263,7 +263,7 @@ end
 # B not provided
 # Construct a matrix on the correct form and of the correct type
 # with the content of I_{n,n}
-function init_B(aproach, ::Nothing, x0)
+function init_B(aproach, ::Nothing, x)
   return I + abs.(0 * x * x')
 end
 

--- a/src/optimize/problem_types.jl
+++ b/src/optimize/problem_types.jl
@@ -267,15 +267,6 @@ function init_B(aproach, ::Nothing, x0)
   return I + abs.(0 * x * x')
 end
 
-# We don't need to maintain a dense matrix for Gradient Descent
-function init_B(aproach::GradientDescent, ::Nothing, x0)
-  return I
-end
-
-function init_B(aproach::LBFGS, ::Nothing, x0)
-  return nothing
-end
-
 # B provided  
 function init_B(aproach, B, x0)
   return B
@@ -286,10 +277,6 @@ function init_f∇fB(prob, scheme, ∇fz, B, x)
    fz, ∇fz = upto_gradient(prob, ∇fz, x)
    return fz, ∇fz, B
 end
-
-function init_f∇fB(prob, scheme::Newton, ∇fz, B, x)
-   upto_hessian(prob, ∇fz, B, x)
-end 
 
 function prepare_variables(prob, approach, x0, ∇fz, B)
     objective = prob.objective

--- a/src/quasinewton/approximations/LBFGS.jl
+++ b/src/quasinewton/approximations/LBFGS.jl
@@ -16,6 +16,7 @@ hasprecon(::LBFGS{<:Inverse,<:Any,<:Any,<:Any}) = HasPrecon()
 
 LBFGS(m::Int = 5) = LBFGS(Inverse(), TwoLoop(), m, nothing)
 LBFGS(approx, m = 5) = LBFGS(approx, TwoLoop(), m, nothing)
+init_B(aproach::LBFGS, ::Nothing, x0) = nothing
 """
 	q holds gradient at current state
 	history is a named tuple of S and Y

--- a/src/quasinewton/approximations/gradient_descent.jl
+++ b/src/quasinewton/approximations/gradient_descent.jl
@@ -4,6 +4,10 @@ struct GradientDescent{T1,TP} <: QuasiNewton{T1}
 end
 GradientDescent() = GradientDescent(Direct(), nothing)
 GradientDescent(m) = GradientDescent(m, nothing)
+
+# We don't need to maintain a dense matrix for Gradient Descent
+init_B(aproach::GradientDescent, ::Nothing, x0) = I
+
 hasprecon(::GradientDescent{<:Any,<:Nothing}) = NoPrecon()
 hasprecon(::GradientDescent{<:Any,<:Any}) = HasPrecon()
 

--- a/src/quasinewton/approximations/newton.jl
+++ b/src/quasinewton/approximations/newton.jl
@@ -14,6 +14,11 @@ end
 function default_newton_linsolve(d, B, g)
     d .= (B \ g)
 end
+
+function init_f∇fB(prob, scheme::Newton, ∇fz, B, x)
+    upto_hessian(prob, ∇fz, B, x)
+ end 
+ 
 Newton(; approx = Direct(), linsolve = default_newton_linsolve, reset_age = nothing) =
     Newton(approx, linsolve, reset_age, nothing)
 summary(::Newton{<:Direct,typeof(default_newton_linsolve)}) =


### PR DESCRIPTION
instead of doing it in a hardcoded way, add two functions that init `B` and `fz,∇fz,B0` respectively. it would help in supporting #52