### PR TITLE
do not allocate in `x_converged`

### DIFF
--- a/src/optimize/problem_types.jl
+++ b/src/optimize/problem_types.jl
@@ -303,7 +303,7 @@ end
 function x_converged(x, z, options)
     x_converged = false
     if x !== nothing # if not calling from initial_converged
-        y = x .- z
+        y = (xi-zi for (xi,zi) in zip(x,z)) #do not allocate if necessary
         ynorm = options.x_norm(y)
         x_converged = x_converged || ynorm ≤ options.x_abstol
         x_converged = x_converged || ynorm ≤ options.x_norm(x) * options.x_reltol


### PR DESCRIPTION
it changes `y = x .- z` for an iterator. ideally, a custom struct could be provided for this, i imagine some problems could arise if using CUArrays?