### PR TITLE
more support for out-of-place trust-region solvers

### DIFF
--- a/src/NLSolvers.jl
+++ b/src/NLSolvers.jl
@@ -139,7 +139,7 @@ export Backtracking, Static, HZAW
 export FFQuadInterp
 
 include("globalization/trs_solvers/root.jl")
-export NWI, Dogleg, NTR
+export NWI, Dogleg, NTR, TCG
 
 # Quasi-Newton (including Newton and gradient descent) functionality
 include("quasinewton/quasinewton.jl")

--- a/src/globalization/trs_solvers/TRS.jl
+++ b/src/globalization/trs_solvers/TRS.jl
@@ -7,7 +7,7 @@ function (ms::TRSolver)(∇f, H, Δ, p)
     x, info = trs(H, ∇f, Δ)
     p .= x[:, 1]
 
-    m = dot(∇f, p) + dot(p, H * p) / 2
+    m = dot(∇f, p) + dot(p, H, p) / 2
     interior = norm(p, 2) ≤ Δ
     return (
         p = p,

--- a/src/globalization/trs_solvers/root.jl
+++ b/src/globalization/trs_solvers/root.jl
@@ -4,6 +4,16 @@
 abstract type TRSPSolver end
 abstract type NearlyExactTRSP <: TRSPSolver end
 
+trs_supports_outofplace(trs) = false
+
+function trs_outofplace_check(trs,prob)
+    if !trs_supports_outofplace(trs)
+        throw(
+            ErrorException("solve() not defined for OutOfPlace() with $(typeof(trs).name.wrapper) for $(typeof(prob).name.wrapper)"),
+        )
+    end
+end
+
 include("solvers/NWI.jl")
 include("solvers/Dogleg.jl")
 include("solvers/NTR.jl")
@@ -11,7 +21,7 @@ include("solvers/TCG.jl")
 #include("subproblemsolvers/TRS.jl") just make an example instead of relying onTRS.jl
 
 function tr_return(; λ, ∇f, H, s, interior, solved, hard_case, Δ, m = nothing)
-    m = m isa Nothing ? dot(∇f, s) + dot(s, H * s) / 2 : m
+    m = m isa Nothing ? dot(∇f, s) + dot(s, H, s) / 2 : m
     (
         p = s,
         mz = m,
@@ -23,13 +33,35 @@ function tr_return(; λ, ∇f, H, s, interior, solved, hard_case, Δ, m = nothin
     )
 end
 
-function update_H!(H, h, λ = nothing)
+update_H!(mstyle::OutOfPlace,H, h, λ) = _update_H(H, h, λ)
+update_H!(mstyle::OutOfPlace,H, h) = _update_H(H, h, nothing)
+update_H!(mstyle::InPlace,H, h, λ) = _update_H!(H, h, λ)
+update_H!(mstyle::InPlace,H, h) = _update_H!(H, h, nothing)
+
+function _update_H!(H, h, λ)
     T = eltype(h)
     n = length(h)
-    if !(λ == T(0))
+    if λ == nothing
         for i = 1:n
-            @inbounds H[i, i] = λ isa Nothing ? h[i] : h[i] + λ
+            @inbounds H[i, i] = h[i]
+        end
+    elseif !(λ == T(0))
+        for i = 1:n
+            @inbounds H[i, i] = h[i] + λ
         end
     end
     H
+end
+
+function _update_H(H, h, λ = nothing)
+    T = eltype(h)
+    if λ == nothing
+        Hd = Diagonal(h)
+        return H + Hd
+    elseif !(λ == T(0))
+        Hd = Diagonal(h)
+        return H + Hd + λ*I
+    else
+        return H
+    end
 end

--- a/src/globalization/trs_solvers/root.jl
+++ b/src/globalization/trs_solvers/root.jl
@@ -56,11 +56,13 @@ end
 function _update_H(H, h, λ = nothing)
     T = eltype(h)
     if λ == nothing
-        Hd = Diagonal(h)
-        return H + Hd
+        h̄ = Diagonal(h)
+        H̄ = H - Diagonal(H)
+        return H̄ + h̄
     elseif !(λ == T(0))
-        Hd = Diagonal(h)
-        return H + Hd + λ*I
+        h̄ = Diagonal(h)
+        H̄ = H - Diagonal(H)
+        return H̄ + h̄ + λ*I
     else
         return H
     end

--- a/src/globalization/trs_solvers/solvers/Dogleg.jl
+++ b/src/globalization/trs_solvers/solvers/Dogleg.jl
@@ -20,6 +20,8 @@ struct Dogleg{T} <: TRSPSolver
 end
 Dogleg() = Dogleg(nothing)
 
+trs_supports_outofplace(trs::Dogleg) = true
+
 function (dogleg::Dogleg)(∇f, H, Δ, p, scheme, mstyle; abstol = 1e-10, maxiter = 50)
     T = eltype(p)
     n = length(∇f)
@@ -80,7 +82,7 @@ function (dogleg::Dogleg)(∇f, H, Δ, p, scheme, mstyle; abstol = 1e-10, maxite
             interior = false
         end
     end
-    m = dot(∇f, p) + dot(p, H * p) / 2
+    m = dot(∇f, p) + dot(p, H, p) / 2
 
     return (
         p = p,

--- a/src/globalization/trs_solvers/solvers/NTR.jl
+++ b/src/globalization/trs_solvers/solvers/NTR.jl
@@ -184,8 +184,7 @@ function (ms::NTR)(
                 if issuccess(F) # Then we're in L, great! lemma 7.3.2
                     λ = λ⁺
                 else # we landed in N, this is bad, so use bounds to approach L
-                    λLλU = abs(λL * λU)
-                    λ = max(sqrt(λLλU), λL + θ * (λU - λL))
+                    λ = max(sqrt(λL * λU), λL + θ * (λU - λL))
                 end
             else # in L, we can safely step
                 λ = λ⁺
@@ -233,7 +232,7 @@ function (ms::NTR)(
             # lower bound, we cannot apply the Newton step here.
             δ, v = λL_in_𝓝(H, F)
             λL = max(λL, λ + δ / dot(v, v)) # update lower bound
-            λ = max(sqrt(λLλU), λL + θ * (λU - λL)) # no convergence possible, so step in bracket
+            λ = max(sqrt(λL * λU), λL + θ * (λU - λL)) # no convergence possible, so step in bracket
         end
     end
     H = update_H!(mstyle, H, h)

--- a/src/globalization/trs_solvers/solvers/NWI.jl
+++ b/src/globalization/trs_solvers/solvers/NWI.jl
@@ -118,10 +118,10 @@ calc_p!(mstyle::MutateStyle, p, Qt∇f, QΛQ, λ) = calc_p!(mstyle, p, Qt∇f, Q
 function calc_p!(mstyle::MutateStyle, p, Qt∇f, QΛQ, λ::T, first_j) where {T}
     inplace = mstyle === InPlace()
     # Reset search direction to 0
-    if inplace
+    p = if inplace
         fill!(p, T(0))
     else
-        p = T(0) .* p
+        T(0) .* p
     end
     # Unpack eigenvalues and eigenvectors
     Λ = QΛQ.values
@@ -131,7 +131,7 @@ function calc_p!(mstyle::MutateStyle, p, Qt∇f, QΛQ, λ::T, first_j) where {T}
         if inplace
             @. p = p - κ * Q[:, j]
         else
-            p = p - κ * Q[:, j]
+            p = p .- κ .* Q[:, j]
         end
     end
     p
@@ -239,7 +239,7 @@ function (ms::NWI)(∇f, H, Δ, p, scheme, mstyle; abstol = 1e-10, maxiter = 50)
             if inplace
                 @. p = -pλ + tau * Q[:, 1]
             else
-                p = -pλ + tau * Q[:, 1]
+                p = tau .* Q[:, 1] .- pλ
             end
             m = dot(∇f, p) + dot(p, H, p) / 2
 

--- a/src/globalization/trs_solvers/solvers/NWI.jl
+++ b/src/globalization/trs_solvers/solvers/NWI.jl
@@ -25,7 +25,7 @@ struct NWI{T} <: NearlyExactTRSP
 end
 NWI() = NWI(eigen)
 summary(::NWI) = "Trust Region (Newton, eigen)"
-
+trs_supports_outofplace(trs::NWI) = true
 """
     initial_safeguards(B, h, g, Δ)
 
@@ -112,19 +112,27 @@ function is_maybe_hard_case(QΛQ, Qt∇f::AbstractVector{T}) where {T}
 end
 
 # Equation 4.38 in N&W (2006)
-calc_p!(p, Qt∇f, QΛQ, λ) = calc_p!(p, Qt∇f, QΛQ, λ, 1)
+calc_p!(mstyle::MutateStyle, p, Qt∇f, QΛQ, λ) = calc_p!(mstyle, p, Qt∇f, QΛQ, λ, 1)
 
 # Equation 4.45 in N&W (2006) since we allow for first_j > 1
-function calc_p!(p, Qt∇f, QΛQ, λ::T, first_j) where {T}
+function calc_p!(mstyle::MutateStyle, p, Qt∇f, QΛQ, λ::T, first_j) where {T}
+    inplace = mstyle === InPlace()
     # Reset search direction to 0
-    fill!(p, T(0))
-
+    if inplace
+        fill!(p, T(0))
+    else
+        p = T(0) .* p
+    end
     # Unpack eigenvalues and eigenvectors
     Λ = QΛQ.values
     Q = QΛQ.vectors
     for j = first_j:length(Λ)
         κ = Qt∇f[j] / (Λ[j] + λ)
-        @. p = p - κ * Q[:, j]
+        if inplace
+            @. p = p - κ * Q[:, j]
+        else
+            p = p - κ * Q[:, j]
+        end
     end
     p
 end
@@ -153,7 +161,7 @@ function (ms::NWI)(∇f, H, Δ, p, scheme, mstyle; abstol = 1e-10, maxiter = 50)
     n = length(∇f)
     H = H isa UniformScaling ? Diagonal(copy(∇f) .* 0 .+ 1) : H
     h = diag(H)
-
+    inplace = mstyle == InPlace()
     # Note that currently the eigenvalues are only sorted if H is perfectly
     # symmetric.  (Julia issue #17093)
     if H isa Diagonal
@@ -176,14 +184,14 @@ function (ms::NWI)(∇f, H, Δ, p, scheme, mstyle; abstol = 1e-10, maxiter = 50)
     # positive, so the Newton step, pN, is fine unless norm(pN, 2) > Δ.
     if λmin >= sqrt(eps(T))
         λ = T(0) # no amount of I is added yet
-        p = calc_p!(p, Qt∇f, QΛQ, λ) # calculate the Newton step
+        p = calc_p!(mstyle, p, Qt∇f, QΛQ, λ) # calculate the Newton step
         if norm(p, 2) ≤ Δ
             # No shrinkage is necessary: -(H \ ∇f) is the minimizer
             interior = true
             solved = true
             hard_case = false
 
-            m = dot(∇f, p) + dot(p, H * p) / 2
+            m = dot(∇f, p) + dot(p, H, p) / 2
 
             return (
                 p = p,
@@ -218,7 +226,7 @@ function (ms::NWI)(∇f, H, Δ, p, scheme, mstyle; abstol = 1e-10, maxiter = 50)
 
         # The old p is discarded, and replaced with one that takes into account
         # the first j such that λj ≠ λmin. Formula 4.45 in N&W (2006)
-        pλ = calc_p!(p, Qt∇f, QΛQ, λ, first_j)
+        pλ = calc_p!(mstyle, p, Qt∇f, QΛQ, λ, first_j)
 
         # Check if the choice of λ leads to a solution inside the trust region.
         # If it does, then we construct the "hard case solution".
@@ -228,9 +236,12 @@ function (ms::NWI)(∇f, H, Δ, p, scheme, mstyle; abstol = 1e-10, maxiter = 50)
 
             tau = sqrt(Δ^2 - norm(pλ, 2)^2)
 
-            @. p = -pλ + tau * Q[:, 1]
-
-            m = dot(∇f, p) + dot(p, H * p) / 2
+            if inplace
+                @. p = -pλ + tau * Q[:, 1]
+            else
+                p = -pλ + tau * Q[:, 1]
+            end
+            m = dot(∇f, p) + dot(p, H, p) / 2
 
             return (
                 p = p,
@@ -257,7 +268,7 @@ function (ms::NWI)(∇f, H, Δ, p, scheme, mstyle; abstol = 1e-10, maxiter = 50)
     λ = safeguard_λ(λ, isg)
     for iter = 1:maxiter
         λ_previous = λ
-        H = update_H!(H, h, λ)
+        H = update_H!(mstyle, H, h, λ)
 
         F =
             H isa Diagonal ? cholesky(H; check = false) :
@@ -271,7 +282,11 @@ function (ms::NWI)(∇f, H, Δ, p, scheme, mstyle; abstol = 1e-10, maxiter = 50)
             continue
         end
         R = F.U
-        p .= R \ (R' \ -∇f)
+        if inplace
+            p .= R \ (R' \ -∇f)
+        else
+            p = R \ (R' \ -∇f)
+        end
         q_l = R' \ p
 
         p_norm = norm(p, 2)
@@ -289,8 +304,8 @@ function (ms::NWI)(∇f, H, Δ, p, scheme, mstyle; abstol = 1e-10, maxiter = 50)
         end
     end
 
-    H = update_H!(H, h)
-    m = dot(∇f, p) + dot(p, H * p) / 2
+    H = update_H!(mstyle, H, h)
+    m = dot(∇f, p) + dot(p, H, p) / 2
     return (
         p = p,
         mz = m,

--- a/src/nlsolve/trustregions/newton.jl
+++ b/src/nlsolve/trustregions/newton.jl
@@ -47,14 +47,9 @@ function solve(
     x,
     approach::TrustRegion{<:Union{SR1,DBFGS,BFGS,Newton},<:Any,<:Any},
     options::NEqOptions,
-)
-  if !(mstyle(prob) === InPlace()) && !(approach.spsolve isa Dogleg)
-        throw(
-            ErrorException(
-                "solve() not defined for OutOfPlace() with Trustregion for NEqProblem",
-            ),
-        )
-    end
+)   
+
+    trs_outofplace_check(approach.spsolve,prob)
     F = prob.R
     # should we wrap a Fx here so we can log F0 info here?
     # and so we can extract it at the end as well?

--- a/src/nlsolve/trustregions/newton.jl
+++ b/src/nlsolve/trustregions/newton.jl
@@ -49,7 +49,7 @@ function solve(
     options::NEqOptions,
 )   
 
-    trs_outofplace_check(approach.spsolve,prob)
+    mstyle(prob) == OutOfPlace() && trs_outofplace_check(approach.spsolve,prob)
     F = prob.R
     # should we wrap a Fx here so we can log F0 info here?
     # and so we can extract it at the end as well?

--- a/src/optimize/trustregions/optimize/inplace_loop.jl
+++ b/src/optimize/trustregions/optimize/inplace_loop.jl
@@ -16,11 +16,8 @@ function solve(
     objvars;
     initial_Δ = 20.0,
 )
-    if !(mstyle(problem) === InPlace()) && !(approach.spsolve == Dogleg())
-        throw(
-            ErrorException("solve() not defined for OutOfPlace() with TrustRegion solvers"),
-        )
-    end
+
+    trs_outofplace_check(approach.spsolve,problem)
     t0 = time()
     T = eltype(objvars.z)
     Δmin = cbrt(eps(T))

--- a/src/optimize/trustregions/optimize/inplace_loop.jl
+++ b/src/optimize/trustregions/optimize/inplace_loop.jl
@@ -17,7 +17,8 @@ function solve(
     initial_Δ = 20.0,
 )
 
-    trs_outofplace_check(approach.spsolve,problem)
+    mstyle(prob) == OutOfPlace() && trs_outofplace_check(approach.spsolve,problem)
+
     t0 = time()
     T = eltype(objvars.z)
     Δmin = cbrt(eps(T))

--- a/src/optimize/trustregions/optimize/inplace_loop.jl
+++ b/src/optimize/trustregions/optimize/inplace_loop.jl
@@ -17,7 +17,7 @@ function solve(
     initial_Δ = 20.0,
 )
 
-    mstyle(prob) == OutOfPlace() && trs_outofplace_check(approach.spsolve,problem)
+    mstyle(problem) == OutOfPlace() && trs_outofplace_check(approach.spsolve,problem)
 
     t0 = time()
     T = eltype(objvars.z)

--- a/src/quasinewton/update_qn.jl
+++ b/src/quasinewton/update_qn.jl
@@ -8,14 +8,14 @@ function update_obj!(problem, s, y, ∇fx, z, ∇fz, B, scheme, scale = nothing)
     # Update B
     if scale == nothing
         if isa(scheme.approx, Direct)
-            yBy = dot(y, B * y)
+            yBy = dot(y, B, y)
             if !iszero(yBy)
                 Badj = dot(y, s) / yBy .* B
             end
         else
             ys = dot(y, s)
             if !iszero(ys)
-                Badj = dot(y, B * y) / ys .* B
+                Badj = dot(y, B, y) / ys .* B
             else
                 return fz, ∇fz, B, s, y
             end
@@ -45,7 +45,7 @@ function update_obj(problem, s, ∇fx, z, ∇fz, B, scheme, scale = nothing)
     # Update B
     if scale == nothing
         if isa(scheme.approx, Direct)
-            yBy = dot(y, B * y)
+            yBy = dot(y, B, y)
             if !iszero(yBy) && isfinite(yBy)
                 Badj = dot(y, s) / yBy * B # this is different than above?
             else
@@ -54,7 +54,7 @@ function update_obj(problem, s, ∇fx, z, ∇fz, B, scheme, scale = nothing)
         else
             ys = dot(y, s)
             if !iszero(ys) && isfinite(ys)
-                Badj = dot(y, B * y) / ys * B
+                Badj = dot(y, B, y) / ys * B
             else
                 Badj = B
             end

--- a/test/nlsolve/interface.jl
+++ b/test/nlsolve/interface.jl
@@ -464,7 +464,7 @@ end
     res = solve(prob, x0, LineSearch(Newton(), Backtracking()))
 end
 
-function solve_static()
+function solve_static(trs)
     function F_rosenbrock_static(Fx, x)
         Fx1 = 1 - x[1]
         Fx2 = 10(x[2] - x[1]^2)
@@ -491,9 +491,12 @@ function solve_static()
 
     prob_static =  NEqProblem(obj; inplace=false)
     x0_static = @SVector([-1.2, 1.0])
-    res = solve(prob_static, x0_static, TrustRegion(Newton(), Dogleg()), NEqOptions())
+    res = solve(prob_static, x0_static, TrustRegion(Newton(), trs), NEqOptions())
 end
 
-solve_static()
-alloced = @allocated solve_static()
-@test alloced == 0
+@testset "out-of-place trust region nlsolves" begin
+    @test iszero(@allocated solve_static(Dogleg()))
+    @test iszero(@allocated solve_static(NWI()))
+    @test iszero(@allocated solve_static(TCG()))
+    #@test iszero(@allocated solve_static(NTR())) #TODO
+end


### PR DESCRIPTION
this is focused in the `NWI` trust region, but `TCG` also supports out of place now (there was some work on NTR, but some parts are still missing)

summary of the changes:
- `update_H!(H,h,lamda) -> update_H!(mstyle, H,h,lamda)`
- new function: `trs_supports_outofplace(trs)`, that turns the support for out-of-place solvers for an specific trust region method.
- `dot(x, H*x) -> dot(x, H, x)` (available since julia 1.4, it should reduce an allocation in the inplace methods)